### PR TITLE
fix: use dedicated OpenAI credentials for CheXprompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,12 +29,12 @@ REDIVIS_API_TOKEN=
 # detects which is present and routes accordingly.
 #
 # (a) OpenAI api and access
-OPENAI_API_KEY=
-OPENAI_BASE_URL='https://api.openai.com/v1'
+CHEXPROMPT_OPENAI_API_KEY=
+CHEXPROMPT_OPENAI_BASE_URL='https://api.openai.com/v1'
 # CHEXPROMPT_DEPLOYMENT=gpt-5.4   # optional; if omitted, defaults to gpt-5.4
 
 # (b) Alternatively, you can set up the following for azure openai access by uncommenting the following.
-# AZURE_OPENAI_API_KEY=
-# AZURE_OPENAI_ENDPOINT=
-# AZURE_OPENAI_API_VERSION=
+# CHEXPROMPT_AZURE_OPENAI_API_KEY=
+# CHEXPROMPT_AZURE_OPENAI_ENDPOINT=
+# CHEXPROMPT_AZURE_OPENAI_API_VERSION=
 # CHEXPROMPT_DEPLOYMENT=gpt-5.4   # optional; if omitted, defaults to gpt-5.4

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ instructions below and fill in the credentials in `.env` (there is a file
 
 ### Setting up other secrets
 
-X-ray Report Correction is scored by an LLM-based judge based on [CheXprompt](https://github.com/microsoft/chexprompt) verifier. We use openai's GPT-5.4 as the default judge. **Configure one of two paths in `.env`** (the
-verifier auto-detects which is present): **(a) vanilla OpenAI** set `OPENAI_API_KEY`, `OPENAI_BASE_URL`, or **(b) Azure OpenAI** —
-set `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, We use GPT-5.4 as the default LLM judge. If you want to change, you can set `CHEXPROMPT_DEPLOYMENT` to a different model deployment.
+X-ray Report Correction is scored by an LLM-based judge based on the [CheXprompt](https://github.com/microsoft/chexprompt) verifier. We use GPT-5.4 as the default judge. **Configure one of two paths in `.env`** (the
+verifier auto-detects which is present): **(a) vanilla OpenAI** — set `CHEXPROMPT_OPENAI_API_KEY` and optionally `CHEXPROMPT_OPENAI_BASE_URL`; or **(b) Azure OpenAI** —
+set `CHEXPROMPT_AZURE_OPENAI_API_KEY`, `CHEXPROMPT_AZURE_OPENAI_ENDPOINT`, and `CHEXPROMPT_AZURE_OPENAI_API_VERSION`. To change the default judge, set `CHEXPROMPT_DEPLOYMENT` to a different model or deployment name.
 
 ### Exporting environment variables from .env
 Make sure you have `.env` at this repo directory so that the containers can read the environment variables. 

--- a/tasks/xray_report_correction_case_01/README.md
+++ b/tasks/xray_report_correction_case_01/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_01/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_01/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_01/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_01/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_01/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_01/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_02/README.md
+++ b/tasks/xray_report_correction_case_02/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_02/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_02/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_02/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_02/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_02/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_02/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_03/README.md
+++ b/tasks/xray_report_correction_case_03/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_03/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_03/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_03/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_03/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_03/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_03/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_04/README.md
+++ b/tasks/xray_report_correction_case_04/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_04/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_04/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_04/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_04/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_04/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_04/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_05/README.md
+++ b/tasks/xray_report_correction_case_05/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_05/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_05/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_05/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_05/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_05/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_05/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_06/README.md
+++ b/tasks/xray_report_correction_case_06/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_06/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_06/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_06/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_06/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_06/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_06/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_07/README.md
+++ b/tasks/xray_report_correction_case_07/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_07/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_07/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_07/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_07/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_07/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_07/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_08/README.md
+++ b/tasks/xray_report_correction_case_08/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_08/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_08/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_08/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_08/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_08/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_08/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_09/README.md
+++ b/tasks/xray_report_correction_case_09/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_09/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_09/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_09/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_09/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_09/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_09/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """

--- a/tasks/xray_report_correction_case_10/README.md
+++ b/tasks/xray_report_correction_case_10/README.md
@@ -6,7 +6,7 @@ Given a MIMIC-CXR study, correct the radiology report FINDINGS. The submission i
 
 **Success criteria:** reward 1.0 iff the report has **zero** clinically-significant errors judged by LLM-judge CheXprompt verifier's majority vote.
 
-> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`OPENAI_API_KEY` / `OPENAI_BASE_URL`, or the Azure `AZURE_OPENAI_*` keys). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
+> **Credentials required.** MIMIC-CXR is PhysioNet-gated — set `PN_USER` / `PN_PASS` in `.env`. Scoring also needs an OpenAI-compatible judge (`CHEXPROMPT_OPENAI_API_KEY` / `CHEXPROMPT_OPENAI_BASE_URL`, or the Azure `CHEXPROMPT_AZURE_OPENAI_*` variables). See [Setting up task access](../../README.md#setting-up-task-access) and [Setting up other secrets](../../README.md#setting-up-other-secrets).
 
 ## Run this task
 

--- a/tasks/xray_report_correction_case_10/environment/docker-compose.yaml
+++ b/tasks/xray_report_correction_case_10/environment/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     env_file:
-      # OPENAI_API_KEY, OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
+      # CHEXPROMPT_OPENAI_API_KEY, CHEXPROMPT_OPENAI_BASE_URL, CHEXPROMPT_DEPLOYMENT (verifier).
       # NOTE: PN_USER / PN_PASS in the same .env do get loaded into main
       # by docker compose, but the verifier doesn't read them — the
       # bootstrap service is what touches PhysioNet. The agent has shell

--- a/tasks/xray_report_correction_case_10/tests/harbor_evaluator.py
+++ b/tasks/xray_report_correction_case_10/tests/harbor_evaluator.py
@@ -25,8 +25,11 @@ structured error string in the result row, so a failed verifier never
 masquerades as a passing agent):
 
   * OpenAI env vars exported before the verifier runs:
-    ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI) or
-    ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+    ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
     ``CHEXPROMPT_DEPLOYMENT`` selects the model / deployment name
     (e.g. ``gpt-4-1106-preview`` or whichever Azure deployment is in use).
 """
@@ -79,32 +82,22 @@ def _configure_openai_for_chexprompt() -> str | None:
     Azure OpenAI based on env vars. Returns an error string if config is
     invalid, None otherwise. Must be called before importing CheXprompt.
 
-    Accepts both naming conventions:
+    Supported configurations:
 
-    * Azure-canonical (preferred when set):
-        ``AZURE_OPENAI_API_KEY`` / ``AZURE_OPENAI_ENDPOINT`` /
-        ``AZURE_OPENAI_API_VERSION``  (deployment via
-        ``AZURE_OPENAI_DEPLOYMENT`` or ``CHEXPROMPT_DEPLOYMENT``).
-    * Legacy openai-SDK names (works for both vanilla and Azure):
-        ``OPENAI_API_KEY`` / ``OPENAI_API_BASE`` / ``OPENAI_API_VERSION``.
-    * Vanilla OpenAI: ``OPENAI_API_KEY`` (+ optional ``OPENAI_BASE_URL``).
+    * Azure OpenAI: ``CHEXPROMPT_AZURE_OPENAI_API_KEY`` /
+      ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT`` /
+      ``CHEXPROMPT_AZURE_OPENAI_API_VERSION``.
+    * Vanilla OpenAI: ``CHEXPROMPT_OPENAI_API_KEY``
+      (+ optional ``CHEXPROMPT_OPENAI_BASE_URL``).
 
-    Detection order: AZURE_OPENAI_* (if endpoint set) → OPENAI_API_BASE
-    + OPENAI_API_VERSION (Azure-shaped) → vanilla OpenAI.
+    Azure is selected when all three Azure variables are present; otherwise
+    configuration falls through to vanilla OpenAI.
     """
     import openai  # noqa: PLC0415 — defer until we have env
 
-    # Azure-canonical naming has priority when both endpoint and key are set.
-    # Endpoint accepts three aliases: ``AZURE_OPENAI_ENDPOINT`` (canonical),
-    # ``AZURE_OPENAI_BASE_URL`` (sometimes used), or ``OPENAI_API_BASE``
-    # (legacy openai-SDK).
-    azure_endpoint = (
-        os.environ.get("AZURE_OPENAI_ENDPOINT")
-        or os.environ.get("AZURE_OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
-    )
-    azure_version = os.environ.get("AZURE_OPENAI_API_VERSION") or os.environ.get("OPENAI_API_VERSION")
-    azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    azure_endpoint = os.environ.get("CHEXPROMPT_AZURE_OPENAI_ENDPOINT")
+    azure_version = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_VERSION")
+    azure_key = os.environ.get("CHEXPROMPT_AZURE_OPENAI_API_KEY")
 
     if azure_endpoint and azure_version and azure_key:
         openai.api_type = "azure"
@@ -114,14 +107,14 @@ def _configure_openai_for_chexprompt() -> str | None:
         return None
 
     # Fall through to vanilla OpenAI.
-    api_key = os.environ.get("OPENAI_API_KEY")
+    api_key = os.environ.get("CHEXPROMPT_OPENAI_API_KEY")
     if not api_key:
         return (
-            "No API key found — set either AZURE_OPENAI_API_KEY "
-            "(+ AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_VERSION) for Azure, "
-            "or OPENAI_API_KEY for vanilla OpenAI."
+            "No API key found — set either CHEXPROMPT_AZURE_OPENAI_API_KEY "
+            "(+ CHEXPROMPT_AZURE_OPENAI_ENDPOINT + CHEXPROMPT_AZURE_OPENAI_API_VERSION) for Azure, "
+            "or CHEXPROMPT_OPENAI_API_KEY for vanilla OpenAI."
         )
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    base_url = os.environ.get("CHEXPROMPT_OPENAI_BASE_URL", "https://api.openai.com/v1")
     for suffix in ("/chat/completions", "/completions"):
         if base_url.endswith(suffix):
             base_url = base_url[: -len(suffix)]
@@ -150,13 +143,8 @@ def _call_chexprompt(reference: str, candidate: str) -> dict[str, Any]:
 
     # Default to gpt-5.4 — it's stricter than gpt-4o at counting clinical
     # errors in radiology FINDINGS, which matches the "no clinically
-    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT
-    # (or AZURE_OPENAI_DEPLOYMENT — same meaning, whichever .env carries).
-    deployment = (
-        os.environ.get("CHEXPROMPT_DEPLOYMENT")
-        or os.environ.get("AZURE_OPENAI_DEPLOYMENT")
-        or "gpt-5.4"
-    )
+    # significant error = pass" bar. Override via CHEXPROMPT_DEPLOYMENT.
+    deployment = os.environ.get("CHEXPROMPT_DEPLOYMENT") or "gpt-5.4"
 
     cfg_err = _configure_openai_for_chexprompt()
     if cfg_err:

--- a/tasks/xray_report_correction_case_10/tests/verify_meta_task.py
+++ b/tasks/xray_report_correction_case_10/tests/verify_meta_task.py
@@ -25,8 +25,11 @@ synthetic-zero for trials with no verifier output).
 
 Required runtime env (verifier process only — agent never sees them):
 
-  * ``OPENAI_API_KEY`` and either ``OPENAI_BASE_URL`` (vanilla OpenAI)
-    or ``OPENAI_API_BASE`` + ``OPENAI_API_VERSION`` (Azure).
+  * ``CHEXPROMPT_OPENAI_API_KEY`` and optional
+    ``CHEXPROMPT_OPENAI_BASE_URL`` (vanilla OpenAI), or
+    ``CHEXPROMPT_AZURE_OPENAI_API_KEY``,
+    ``CHEXPROMPT_AZURE_OPENAI_ENDPOINT``, and
+    ``CHEXPROMPT_AZURE_OPENAI_API_VERSION`` (Azure).
   * ``CHEXPROMPT_DEPLOYMENT``  — model / deployment name
     (e.g. ``gpt-4-1106-preview``).
 """


### PR DESCRIPTION
## Summary

Use dedicated API environment variables for the CheXprompt verifier instead of the shared `OPENAI_API_KEY` and `OPENAI_BASE_URL`.

This allows benchmark agents and the CheXprompt judge to use different models, API keys, and endpoints without their configurations conflicting.

## Changes

- Replace `OPENAI_API_KEY` and `OPENAI_BASE_URL` with:
  - `CHEXPROMPT_OPENAI_API_KEY`
  - `CHEXPROMPT_OPENAI_BASE_URL`
- Add dedicated Azure OpenAI variables:
  - `CHEXPROMPT_AZURE_OPENAI_API_KEY`
  - `CHEXPROMPT_AZURE_OPENAI_ENDPOINT`
  - `CHEXPROMPT_AZURE_OPENAI_API_VERSION`
- Continue using `CHEXPROMPT_DEPLOYMENT` to select the judge model or deployment.
- Update all X-ray report correction verifiers, examples, and documentation.

## Motivation

When the agent under evaluation uses a different model or API provider from the CheXprompt judge, the two components need separate credentials and base URLs. Reusing the generic OpenAI variables can cause the verifier to connect to the agent’s endpoint or use incompatible credentials.

These dedicated variables isolate the judge configuration from the model being evaluated.
